### PR TITLE
Add VS Code Devcontainer

### DIFF
--- a/.github/workflows/latex_build.yml
+++ b/.github/workflows/latex_build.yml
@@ -1,0 +1,19 @@
+name: Build LaTeX document
+on: [push]
+
+jobs:
+  build_latex:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v3
+      - name: Compile LaTeX document
+        uses: dante-ev/latex-action@latest
+        with:
+          root_file: root.tex
+          args: -synctex=0 -interaction=nonstopmode --shell-escape -pdf -file-line-error
+      - name: Save PDF as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: root.pdf
+          path: root.pdf

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,16 @@
+image: texlive/texlive:latest-full
+
+variables:
+  FILE_NAME: "root"
+
+stages:
+  - build
+
+pdflatex:
+  stage: build
+  script:
+    - latexmk -synctex=0 -interaction=nonstopmode --shell-escape -pdf -file-line-error $FILE_NAME.tex
+  artifacts:
+    paths:
+      - $FILE_NAME.pdf
+    expire_in: 4 weeks

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".devcontainer"]
+	path = .devcontainer
+	url = https://github.com/a-nau/latex-devcontainer.git

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,127 @@
+{
+    "files.exclude": {
+        "**/.git": true,
+        "**/.svn": true,
+        "**/.hg": true,
+        "**/CVS": true,
+        "**/.DS_Store": true,
+        "**/Thumbs.db": true,
+        "**/*.aux": true,
+        "**/*.bbl": true,
+        "**/*.fls": true,
+        "**/*.ind": true,
+        "**/*.nlo": true,
+        "**/*.lot": true,
+        "**/*.out": true,
+        "**/*.ldx": true,
+        "**/*.blg": true,
+        "**/*.idx": true,
+        "**/*.ilg": true,
+        "**/*.lof": true,
+        "**/*.toc": true,
+        "**/*.fdb_latexmk": true,
+        "**/*.log": true,
+        "**/*.bcf": true,
+        "**/*.run.xml": true,
+        "**/*.acn": true,
+        "**/*.glo": true,
+        "**/*.ist": true
+    },
+    "editor.wordWrap": "bounded",
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "nickfode.latex-formatter",
+    "spellright.language": [
+        "en"
+    ],
+    "latex-workshop.latex.autoBuild.run": "onSave",
+    "latex-workshop.view.pdf.viewer": "tab",
+    "latex-workshop.intellisense.bibtexJSON.replace": {},
+    "latex-workshop.latex.pdfWatch.delay": 300,
+    "latex-workshop.synctex.afterBuild.enabled": true,
+    "latex-workshop.latex.recipes": [
+        {
+            "name": "latexmk",
+            "tools": [
+                "latexmk"
+            ]
+        },
+        {
+            "name": "pdflatex -> bibtex -> pdflatex * 2",
+            "tools": [
+                "pdflatex",
+                "bibtex",
+                "pdflatex",
+                "pdflatex"
+            ]
+        },
+        {
+            "name": "bibtex",
+            "tools": [
+                "bibtex"
+            ]
+        },
+        {
+            "name": "link-checker",
+            "tools": [
+                "pdflinkchecker"
+            ]
+        },
+        {
+            "name": "prepare arxiv",
+            "tools": [
+                "prepare_arxiv",
+            ]
+        },
+    ],
+    "latex-workshop.latex.tools": [
+        {
+            "name": "latexmk",
+            "command": "latexmk",
+            "args": [
+                "-synctex=1",
+                "-interaction=nonstopmode",
+                "-file-line-error",
+                "--shell-escape",
+                "-pdf",
+                "-outdir=%OUTDIR%",
+                "%DOC%"
+            ],
+            "env": {}
+        },
+        {
+            "name": "pdflatex",
+            "command": "pdflatex",
+            "args": [
+                "-synctex=1",
+                "-interaction=nonstopmode",
+                "-file-line-error",
+                "%DOC%"
+            ],
+            "env": {}
+        },
+        {
+            "name": "bibtex",
+            "command": "bibtex",
+            "args": [
+                "%DOCFILE%"
+            ],
+            "env": {}
+        },
+        {
+            "name": "pdflinkchecker",
+            "command": "pdflinkchecker",
+            "args": [
+                "%DIR%"
+            ],
+            "env": {}
+        },
+        {
+            "name": "prepare_arxiv",
+            "command": "sh",
+            "args": [
+                "%DIR%/.devcontainer/misc/prepare_arxiv.sh"
+            ],
+            "env": {}
+        },
+    ]
+}

--- a/root.tex
+++ b/root.tex
@@ -20,8 +20,8 @@
 \input{10_conclusion}
 
 {\small
-\bibliographystyle{ieee_fullname}
-\bibliography{11_references}
+    \bibliographystyle{ieee_fullname}
+    \bibliography{11_references}
 }
 
 \ifarxiv \clearpage \input{12_appendix} \fi


### PR DESCRIPTION
Thanks for the helpful template!

I created a [small project](https://github.com/a-nau/latex-devcontainer) to make using LaTeX with Visual Studio Code hassle-free by creating a ready-to-use Devcontainer with

- Common LaTeX Plugins
- Gitlab and Github CI
- One-click arXiv export
- One-click URL check

This might be helpful to some people using the template. If you think it is interesting to enough people, feel free to merge this PR or to add a pointer to the repository.

Best
Alex